### PR TITLE
Replace `map_while` by a stable version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavefront"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Wavefront OBJ parser and utility crate"
 authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
 license = "Apache-2.0 AND MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,6 @@
 //!
 //! <center><img src="https://raw.githubusercontent.com/zesterer/wavefront/master/misc/screenshot.png" alt="A parsec isn't a unit of time, Han" width="50%"/></center>
 
-#![feature(iter_map_while)]
-
 use std::{
     io::{self, Read, Write},
     path::Path,
@@ -105,7 +103,7 @@ impl Obj {
             let mut terms = line.split_ascii_whitespace();
             match terms.next() {
                 Some("v") => {
-                    let mut nums = terms.map_while(|t| t.parse().ok());
+                    let mut nums = terms.map(|t| t.parse()).take_while(Result::is_ok).map(Result::unwrap);
                     positions.push([
                         nums.next().unwrap_or(0.0),
                         nums.next().unwrap_or(0.0),
@@ -113,7 +111,7 @@ impl Obj {
                     ]);
                 },
                 Some("vt") => {
-                    let mut nums = terms.map_while(|t| t.parse().ok());
+                    let mut nums = terms.map(|t| t.parse()).take_while(Result::is_ok).map(Result::unwrap);
                     uvs.push([
                         nums.next().unwrap_or(0.0),
                         nums.next().unwrap_or(0.0),
@@ -121,7 +119,7 @@ impl Obj {
                     ]);
                 },
                 Some("vn") => {
-                    let mut nums = terms.map_while(|t| t.parse().ok());
+                    let mut nums = terms.map(|t| t.parse()).take_while(Result::is_ok).map(Result::unwrap);
                     normals.push([
                         nums.next().unwrap_or(0.0),
                         nums.next().unwrap_or(0.0),
@@ -179,7 +177,7 @@ impl Obj {
                 },
                 Some("g") => {
                     selected_groups = terms
-                        .map_while(|t| Some(t).filter(|t| util::name_is_valid(t)))
+                        .filter(|t| util::name_is_valid(t))
                         .map(|g| {
                             groups.entry(g.to_string()).or_default();
                             g.to_string()
@@ -199,8 +197,8 @@ impl Obj {
 
                     // Create new object
                     let name = terms
-                        .map_while(|t| Some(t).filter(|t| util::name_is_valid(t)))
                         .next()
+                        .filter(|t| util::name_is_valid(t))
                         .ok_or_else(|| Error::ExpectedName(line_num))?
                         .to_string();
                     object.0 = Some(name);


### PR DESCRIPTION
This makes `wavefront` available on stable toolchains. While the code is less clean, I think this is a fair tradeoff